### PR TITLE
Create fields.json if it doesn't exist

### DIFF
--- a/site/js/farms.js
+++ b/site/js/farms.js
@@ -792,7 +792,7 @@ async function loadFieldManagement() {
     }
     catch (e) {
         if (e.code == 'NoSuchKey') {
-            let x = await putJSON('fields/fields.json', {
+            await putJSON('fields/fields.json', {
                 "type": "FeatureCollection",
                 "name": "userFields",
                 "crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },


### PR DESCRIPTION
Fixes the application giving an error when you logged in and you didn't already have a `fields.json`.

I arbitrarily picked one of the fields as a "default field" since the app doesn't yet handle the situation where you've defined zero fields.